### PR TITLE
fix(spec): QM audit remediation — German duties, missing stories, link separators

### DIFF
--- a/docs/syspilot/design/spec_agent_arch.rst
+++ b/docs/syspilot/design/spec_agent_arch.rst
@@ -153,7 +153,7 @@ Meta-level definitions of Soul, Duties, and Workflow concepts.
    :id: SYSP_SPEC_AGENT_ARCH_PROMPT
    :status: draft
    :tags: agent-v2, meta, architecture, prompt
-   :links: SYSP_REQ_AGENT_ARCH_PROMPT; SYSP_REQ_PM_PROMPT; SYSP_REQ_CM_PROMPT; SYSP_REQ_QM_PROMPT; SYSP_REQ_SETUP_PROMPT
+   :links: SYSP_REQ_AGENT_ARCH_PROMPT, SYSP_REQ_PM_PROMPT, SYSP_REQ_CM_PROMPT, SYSP_REQ_QM_PROMPT, SYSP_REQ_SETUP_PROMPT
 
    **Definition:**
 

--- a/docs/syspilot/design/spec_change_mgr.rst
+++ b/docs/syspilot/design/spec_change_mgr.rst
@@ -155,6 +155,6 @@ Change Manager Design
    * **description:** ``"Central orchestrator of the change workflow. Receives Change Requests, invokes engineers in sequence, enforces quality gates, and reports completion with full traceability."``
    * **tools:** ``[read, edit, search, agent, agent/runSubagent, todo, execute, syspilot_jarvis_tools]``
    * **user-invocable:** ``true``
-   * **agents:** ``["syspilot.design", "syspilot.uat", "syspilot.implement", "syspilot.mece", "syspilot.trace", "syspilot.release", "syspilot.docu"]``
+   * **agents:** ``["syspilot.design", "syspilot.uat", "syspilot.implement", "syspilot.mece", "syspilot.trace", "syspilot.release", "syspilot.docu", "syspilot.verify"]``
 
    **File:** ``syspilot.cm.agent.md``

--- a/docs/syspilot/design/spec_doc_scope.rst
+++ b/docs/syspilot/design/spec_doc_scope.rst
@@ -202,7 +202,7 @@ Design specifications defining the structure and content of each documentation f
 
 .. spec:: Copilot Instructions Template Guidance
    :id: SYSP_SPEC_DOC_COPILOT_INSTRUCTIONS
-   :status: open
+   :status: draft
    :tags: agent-v2, documentation, internal, copilot-instructions
    :links: SYSP_REQ_DOC_COPILOT_INSTRUCTIONS, SYSP_SPEC_AGENT_ARCH_SOUL, SYSP_SPEC_SKILL_BRANCHING_STRATEGY, SYSP_SPEC_SKILL_ORCHESTRATION_PATTERN
 

--- a/docs/syspilot/design/spec_skill_ask_questions.rst
+++ b/docs/syspilot/design/spec_skill_ask_questions.rst
@@ -8,7 +8,7 @@ Design specifications for the ask_questions tool API and usage rules.
    :id: SYSP_SPEC_SKILL_ASK_QUESTIONS_API
    :status: approved
    :tags: agent-v2, skill, ask-questions, dx
-   :links: SYSP_REQ_SKILL_ASK_QUESTIONS_USAGE; SYSP_REQ_SKILL_ASK_QUESTIONS_FORMAT
+   :links: SYSP_REQ_SKILL_ASK_QUESTIONS_USAGE, SYSP_REQ_SKILL_ASK_QUESTIONS_FORMAT
 
    **Definition:**
 
@@ -50,7 +50,7 @@ Design specifications for the ask_questions tool API and usage rules.
    :id: SYSP_SPEC_SKILL_ASK_QUESTIONS_RULES
    :status: approved
    :tags: agent-v2, skill, ask-questions, dx
-   :links: SYSP_REQ_SKILL_ASK_QUESTIONS_USAGE; SYSP_REQ_SKILL_ASK_QUESTIONS_FORMAT
+   :links: SYSP_REQ_SKILL_ASK_QUESTIONS_USAGE, SYSP_REQ_SKILL_ASK_QUESTIONS_FORMAT
 
    **Definition:**
 

--- a/docs/syspilot/design/spec_skill_branching.rst
+++ b/docs/syspilot/design/spec_skill_branching.rst
@@ -63,7 +63,7 @@ Design specifications for the Git branching strategy.
    :id: SYSP_SPEC_SKILL_BRANCHING_PERMISSIONS
    :status: approved
    :tags: agent-v2, skill, branching, workflow
-   :links: SYSP_REQ_SKILL_BRANCHING_MAIN_PROTECTION; SYSP_REQ_SKILL_BRANCHING_NAMING
+   :links: SYSP_REQ_SKILL_BRANCHING_MAIN_PROTECTION, SYSP_REQ_SKILL_BRANCHING_NAMING
 
    **Definition:**
 

--- a/docs/syspilot/design/spec_skill_impact.rst
+++ b/docs/syspilot/design/spec_skill_impact.rst
@@ -126,7 +126,7 @@ Design specifications for the impact analysis skill.
    :id: SYSP_SPEC_SKILL_IMPACT_GROUP
    :status: draft
    :tags: agent-v2, skill, impact, architecture
-   :links: SYSP_REQ_SKILL_IMPACT_GROUP; SYSP_SPEC_SKILL_ARCH_FRONTMATTER
+   :links: SYSP_REQ_SKILL_IMPACT_GROUP, SYSP_SPEC_SKILL_ARCH_FRONTMATTER
 
    **Definition:**
 

--- a/docs/syspilot/design/spec_skill_orchestration.rst
+++ b/docs/syspilot/design/spec_skill_orchestration.rst
@@ -8,7 +8,7 @@ Design specifications for the agent orchestration skill.
    :id: SYSP_SPEC_SKILL_ORCHESTRATION_PATTERN
    :status: approved
    :tags: agent-v2, skill, orchestration, architecture
-   :links: SYSP_REQ_SKILL_ORCHESTRATION_INVOKE; SYSP_REQ_SKILL_ORCHESTRATION_FRONTMATTER; SYSP_SPEC_SKILL_ORCHESTRATION_VERB_MODEL
+   :links: SYSP_REQ_SKILL_ORCHESTRATION_INVOKE, SYSP_REQ_SKILL_ORCHESTRATION_FRONTMATTER, SYSP_SPEC_SKILL_ORCHESTRATION_VERB_MODEL
 
    **Definition:**
 
@@ -107,7 +107,7 @@ Design specifications for the agent orchestration skill.
    :id: SYSP_SPEC_SKILL_ORCHESTRATION_CONTRACT
    :status: approved
    :tags: agent-v2, skill, orchestration, architecture
-   :links: SYSP_REQ_SKILL_ORCHESTRATION_INVOKE; SYSP_REQ_SKILL_ORCHESTRATION_GROUP
+   :links: SYSP_REQ_SKILL_ORCHESTRATION_INVOKE, SYSP_REQ_SKILL_ORCHESTRATION_GROUP
 
    **Definition:**
 
@@ -157,7 +157,7 @@ Design specifications for the agent orchestration skill.
    :id: SYSP_SPEC_SKILL_ORCHESTRATION_VERB_MODEL
    :status: draft
    :tags: agent-v2, skill, orchestration, architecture
-   :links: SYSP_REQ_SKILL_ORCHESTRATION_INVOKE; SYSP_SPEC_SKILL_ORCHESTRATION_PATTERN; SYSP_SPEC_SKILL_ORCHESTRATION_CONTRACT
+   :links: SYSP_REQ_SKILL_ORCHESTRATION_INVOKE, SYSP_SPEC_SKILL_ORCHESTRATION_PATTERN, SYSP_SPEC_SKILL_ORCHESTRATION_CONTRACT
 
    **Definition:**
 
@@ -205,7 +205,7 @@ Design specifications for the agent orchestration skill.
    :id: SYSP_SPEC_SKILL_ORCHESTRATION_GROUP
    :status: draft
    :tags: agent-v2, skill, orchestration, architecture
-   :links: SYSP_REQ_SKILL_ORCHESTRATION_GROUP; SYSP_SPEC_SKILL_ARCH_FRONTMATTER
+   :links: SYSP_REQ_SKILL_ORCHESTRATION_GROUP, SYSP_SPEC_SKILL_ARCH_FRONTMATTER
 
    **Definition:**
 
@@ -233,7 +233,7 @@ Design specifications for the agent orchestration skill.
    :status: draft
    :priority: mandatory
    :tags: agent-v2, skill, orchestration, architecture
-   :links: SYSP_REQ_SKILL_ORCHESTRATION_AGENT_VOCAB; SYSP_SPEC_SKILL_ORCHESTRATION_VERB_MODEL
+   :links: SYSP_REQ_SKILL_ORCHESTRATION_AGENT_VOCAB, SYSP_SPEC_SKILL_ORCHESTRATION_VERB_MODEL
 
    **Definition:**
 

--- a/docs/syspilot/design/spec_system_designer.rst
+++ b/docs/syspilot/design/spec_system_designer.rst
@@ -5,7 +5,7 @@ System Designer
 .. spec:: System Designer Soul
    :id: SYSP_SPEC_DESIGN_SOUL
    :status: approved
-   :tags: agent-v2, engineer, change, soul
+   :tags: agent-v2, engineer, design, soul
    :links: SYSP_REQ_DESIGN_SOUL
 
    **Soul:**
@@ -24,7 +24,7 @@ System Designer
 .. spec:: System Designer Duties
    :id: SYSP_SPEC_DESIGN_DUTIES
    :status: draft
-   :tags: agent-v2, engineer, change, duties
+   :tags: agent-v2, engineer, design, duties
    :links: SYSP_REQ_DESIGN_DUTIES
 
    **Duties:**

--- a/docs/syspilot/design/spec_verify_engineer.rst
+++ b/docs/syspilot/design/spec_verify_engineer.rst
@@ -76,7 +76,7 @@ Verify Engineer Design
 
 .. spec:: Verify Engineer Frontmatter
    :id: SYSP_SPEC_VERIFY_FRONTMATTER
-   :status: draft
+   :status: approved
    :tags: agent-v2, engineer, verify, frontmatter
    :links: SYSP_REQ_VERIFY_FRONTMATTER
 

--- a/docs/syspilot/requirements/index.rst
+++ b/docs/syspilot/requirements/index.rst
@@ -33,6 +33,8 @@ This section contains system requirements following Sphinx-Needs methodology.
    req_uat_skill_orchestration_vocab
    req_uat_installer_spec_rewrite
 
+   req_jarvis
+
    req_documentation
 
 

--- a/docs/syspilot/requirements/req_change_mgr.rst
+++ b/docs/syspilot/requirements/req_change_mgr.rst
@@ -82,7 +82,7 @@ Change Manager Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, manager, cm, frontmatter
-   :links: SYSP_US_CM; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_CM, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Change Manager agent SHALL be configured with YAML frontmatter that
@@ -106,7 +106,7 @@ Change Manager Requirements
    :status: draft
    :priority: mandatory
    :tags: agent-v2, manager, cm, prompt
-   :links: SYSP_US_CM; SYSP_REQ_AGENT_ARCH_PROMPT
+   :links: SYSP_US_CM, SYSP_REQ_AGENT_ARCH_PROMPT
 
    **Description:**
    The Change Manager SHALL have a prompt file ``syspilot.cm.prompt.md`` that

--- a/docs/syspilot/requirements/req_dev_engineer.rst
+++ b/docs/syspilot/requirements/req_dev_engineer.rst
@@ -66,7 +66,7 @@ Dev Engineer Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, engineer, implement, frontmatter
-   :links: SYSP_US_IMPLEMENT; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_IMPLEMENT, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Dev Engineer agent SHALL be configured with YAML frontmatter that

--- a/docs/syspilot/requirements/req_docu_engineer.rst
+++ b/docs/syspilot/requirements/req_docu_engineer.rst
@@ -66,7 +66,7 @@ Documentation Engineer Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, engineer, docu, frontmatter
-   :links: SYSP_US_DOCU; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_DOCU, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Documentation Engineer agent SHALL be configured with YAML frontmatter

--- a/docs/syspilot/requirements/req_jarvis.rst
+++ b/docs/syspilot/requirements/req_jarvis.rst
@@ -1,0 +1,75 @@
+Jarvis Inter-Agent Communication Requirements
+==============================================
+
+Requirements for the Jarvis inter-agent messaging mechanism.
+
+
+.. req:: Jarvis Messaging Tool
+   :id: SYSP_REQ_JARVIS_TOOL
+   :status: draft
+   :priority: mandatory
+   :tags: agent-v2, infrastructure, jarvis
+   :links: SYSP_US_JARVIS
+
+   **Description:**
+   The syspilot system SHALL provide a ``syspilot_jarvis_tools`` tool that
+   enables manager agents to send structured messages to other agent sessions
+   without requiring user mediation.
+
+   **Acceptance Criteria:**
+
+   * AC-1: A ``syspilot_jarvis_tools`` tool exists and exposes a
+     ``jarvis_sendToSession`` function
+   * AC-2: ``jarvis_sendToSession`` accepts a target session identifier and a
+     structured message payload
+   * AC-3: Messages sent via Jarvis are delivered to the target agent session
+     without user relay
+   * AC-4: The tool is declared in the ``tools:`` frontmatter of every agent
+     that sends or receives Jarvis messages
+
+
+.. req:: Jarvis Message Contract
+   :id: SYSP_REQ_JARVIS_CONTRACT
+   :status: draft
+   :priority: mandatory
+   :tags: agent-v2, infrastructure, jarvis
+   :links: SYSP_US_JARVIS
+
+   **Description:**
+   Messages sent via Jarvis SHALL follow a defined payload structure so that
+   receiving agents can reliably parse and act on them.
+
+   **Acceptance Criteria:**
+
+   * AC-1: Every Jarvis message includes a ``type`` field identifying the message
+     category (e.g., ``change-complete``, ``findings-report``,
+     ``merge-approval``, ``post-merge-confirmation``)
+   * AC-2: Every Jarvis message includes a ``sender`` field identifying the
+     originating agent
+   * AC-3: Every Jarvis message includes a ``payload`` field containing the
+     structured content specific to the message type
+   * AC-4: The ``change-complete`` message type includes the Change Document
+     path and a summary
+   * AC-5: The ``post-merge-confirmation`` message type includes the merge
+     commit hash and branch name
+
+
+.. req:: Jarvis Agent Frontmatter Declarations
+   :id: SYSP_REQ_JARVIS_FRONTMATTER
+   :status: draft
+   :priority: mandatory
+   :tags: agent-v2, infrastructure, jarvis, frontmatter
+   :links: SYSP_US_JARVIS, SYSP_REQ_AGENT_ARCH_FRONTMATTER
+
+   **Description:**
+   Every agent that sends or receives Jarvis messages SHALL declare
+   ``syspilot_jarvis_tools`` in its ``tools:`` frontmatter field.
+
+   **Acceptance Criteria:**
+
+   * AC-1: ``syspilot.cm`` frontmatter includes ``syspilot_jarvis_tools``
+     (sender: change-complete, post-merge-confirmation)
+   * AC-2: ``syspilot.qm`` frontmatter includes ``syspilot_jarvis_tools``
+     (sender: findings-report)
+   * AC-3: ``syspilot.pm`` frontmatter includes ``syspilot_jarvis_tools``
+     (receiver: all types, sender: merge-approval)

--- a/docs/syspilot/requirements/req_project_mgr.rst
+++ b/docs/syspilot/requirements/req_project_mgr.rst
@@ -80,7 +80,7 @@ Project Manager Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, manager, pm, frontmatter
-   :links: SYSP_US_PM; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_PM, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Project Manager agent SHALL be configured with YAML frontmatter that
@@ -104,7 +104,7 @@ Project Manager Requirements
    :status: draft
    :priority: mandatory
    :tags: agent-v2, manager, pm, prompt
-   :links: SYSP_US_PM; SYSP_REQ_AGENT_ARCH_PROMPT
+   :links: SYSP_US_PM, SYSP_REQ_AGENT_ARCH_PROMPT
 
    **Description:**
    The Project Manager SHALL have a prompt file ``syspilot.pm.prompt.md`` that

--- a/docs/syspilot/requirements/req_quality_mece.rst
+++ b/docs/syspilot/requirements/req_quality_mece.rst
@@ -64,7 +64,7 @@ Quality Engineer MECE Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, engineer, mece, frontmatter
-   :links: SYSP_US_MECE; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_MECE, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Quality Engineer MECE agent SHALL be configured with YAML frontmatter

--- a/docs/syspilot/requirements/req_quality_mgr.rst
+++ b/docs/syspilot/requirements/req_quality_mgr.rst
@@ -68,7 +68,7 @@ Quality Manager Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, manager, qm, frontmatter
-   :links: SYSP_US_QM; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_QM, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Quality Manager agent SHALL be configured with YAML frontmatter that
@@ -91,7 +91,7 @@ Quality Manager Requirements
    :status: draft
    :priority: mandatory
    :tags: agent-v2, manager, qm, prompt
-   :links: SYSP_US_QM; SYSP_REQ_AGENT_ARCH_PROMPT
+   :links: SYSP_US_QM, SYSP_REQ_AGENT_ARCH_PROMPT
 
    **Description:**
    The Quality Manager SHALL have a prompt file ``syspilot.qm.prompt.md`` that

--- a/docs/syspilot/requirements/req_quality_trace.rst
+++ b/docs/syspilot/requirements/req_quality_trace.rst
@@ -64,7 +64,7 @@ Quality Engineer Trace Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, engineer, trace, frontmatter
-   :links: SYSP_US_TRACE; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_TRACE, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Quality Engineer Trace agent SHALL be configured with YAML frontmatter

--- a/docs/syspilot/requirements/req_release_engineer.rst
+++ b/docs/syspilot/requirements/req_release_engineer.rst
@@ -72,7 +72,7 @@ Release Engineer Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, engineer, release, frontmatter
-   :links: SYSP_US_RELEASE; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_RELEASE, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Release Engineer agent SHALL be configured with YAML frontmatter that

--- a/docs/syspilot/requirements/req_setup_engineer.rst
+++ b/docs/syspilot/requirements/req_setup_engineer.rst
@@ -292,7 +292,7 @@ Setup Manager Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, manager, setup, frontmatter
-   :links: SYSP_US_SETUP; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_SETUP, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Setup Manager agent SHALL be configured with YAML Agent Frontmatter that
@@ -311,7 +311,7 @@ Setup Manager Requirements
    :status: draft
    :priority: mandatory
    :tags: agent-v2, manager, setup, prompt
-   :links: SYSP_US_SETUP; SYSP_REQ_AGENT_ARCH_PROMPT
+   :links: SYSP_US_SETUP, SYSP_REQ_AGENT_ARCH_PROMPT
 
    **Description:**
    The Setup Manager SHALL have a prompt file ``syspilot.setup.prompt.md`` that

--- a/docs/syspilot/requirements/req_system_designer.rst
+++ b/docs/syspilot/requirements/req_system_designer.rst
@@ -68,7 +68,7 @@ System Designer Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, engineer, change, frontmatter
-   :links: SYSP_US_DESIGN; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_DESIGN, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The System Designer agent SHALL be configured with YAML frontmatter that

--- a/docs/syspilot/requirements/req_test_engineer.rst
+++ b/docs/syspilot/requirements/req_test_engineer.rst
@@ -65,7 +65,7 @@ Test Engineer Requirements
    :status: approved
    :priority: mandatory
    :tags: agent-v2, engineer, uat, frontmatter
-   :links: SYSP_US_UAT; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_UAT, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Test Engineer agent SHALL be configured with YAML frontmatter that

--- a/docs/syspilot/requirements/req_verify_engineer.rst
+++ b/docs/syspilot/requirements/req_verify_engineer.rst
@@ -67,7 +67,7 @@ Verify Engineer Requirements
    :status: draft
    :priority: mandatory
    :tags: agent-v2, engineer, verify, frontmatter
-   :links: SYSP_US_VERIFY; SYSP_REQ_AGENT_ARCH_FRONTMATTER
+   :links: SYSP_US_VERIFY, SYSP_REQ_AGENT_ARCH_FRONTMATTER
 
    **Description:**
    The Verify Engineer agent SHALL be configured with YAML frontmatter that

--- a/docs/syspilot/userstories/index.rst
+++ b/docs/syspilot/userstories/index.rst
@@ -32,6 +32,10 @@ This section contains user stories that drive the requirements.
    us_uat_skill_orchestration_vocab
    us_uat_installer_spec_rewrite
 
+   us_installer
+   us_jarvis
+   us_schema_check
+
    us_documentation
 
 

--- a/docs/syspilot/userstories/us_change_mgr.rst
+++ b/docs/syspilot/userstories/us_change_mgr.rst
@@ -23,14 +23,19 @@ Change Manager Agent
    details, it treats them as imprecise intent and works to clarify.
 
    **Duties:**
-   Der Change Manager ist verantwortlich für:
 
-   * die Übersetzung zwischen User-Intent (CR) und ausgeführter Spezifikations-Arbeit — kein Engineer wird mit Roh-Intent konfrontiert, kein User mit Engineer-Detail
-   * die Vollständigkeit der Pipeline — kein freigegebener Change verlässt CM ohne Spezifikation, Test-Artefakte, Implementierung, Quality Gates und Dokumentation
-   * die Trennung zwischen Engineers — keine Engineer-Session muss von einer anderen wissen
-   * die Nachvollziehbarkeit des Change-Verlaufs — das Change Document ist zu jedem Zeitpunkt der wahre Zustand, auch nach Abbruch; PM erstellt das Dokument (Template-Kopie), CM füllt die Engineering-Sektionen
-   * die Merge-Abstinenz — CM merged niemals nach ``development``; CM signalisiert Bereitschaft an PM, PM führt den Merge durch
-   * die Rückmeldung an PM nach Abschluss — kein Change verschwindet stillschweigend; CM sendet Bereitschaftsmeldung mit Branch-Name und Change-Document-Pfad
+   * Translate user intent (CR) into executed specification work — no engineer
+     receives raw intent, no user receives engineer detail
+   * Guarantee pipeline completeness — no approved change leaves CM without
+     specification, test artifacts, implementation, quality gates, and
+     documentation
+   * Keep engineers decoupled — no engineer session needs knowledge of another
+   * Maintain Change Document integrity — the Change Document reflects the true
+     state at all times, including after abort or failure
+   * Uphold merge authority — CM never merges to ``development``; CM signals
+     readiness to PM, PM performs the merge
+   * Report back to PM after completion — no change completes silently; CM sends
+     a readiness notification with branch name and Change Document path
 
    **Workflow (high-level):**
    Receive CR → Intent Gate → Change Document → System Designer → Test Engineer →

--- a/docs/syspilot/userstories/us_dev_engineer.rst
+++ b/docs/syspilot/userstories/us_dev_engineer.rst
@@ -22,12 +22,16 @@ Dev Engineer Agent
    modifies specifications — that is the System Designer's job.
 
    **Duties:**
-   Der Dev Engineer ist verantwortlich für:
 
-   * die Übereinstimmung zwischen approved Specs und Implementation-Artefakten — kein Spec-Element ohne korrespondierende Code/Test/Doku-Änderung, kein Code ohne Spec-Anker
-   * die Funktionsfähigkeit der Implementierung — alle Tests grün, kein Build defekt nach Abschluss
-   * die Disziplin der Spec-Unverletzlichkeit — der Dev Engineer ändert keine Spec-Inhalte und keine Spec-Status
-   * die Nachvollziehbarkeit jeder Code-Änderung — Commits referenzieren das Change Document, keine Implementierung ohne Spur
+   * Ensure correspondence between approved specs and implementation artifacts —
+     no spec element without a corresponding code/test/doc change, no code
+     without a spec anchor
+   * Guarantee implementation correctness — all tests pass, no build is
+     defective after completion
+   * Respect specification integrity — never modify spec content or spec
+     statuses
+   * Maintain traceability of every code change — every commit references the
+     Change Document
 
    **Workflow (high-level):**
    Read Change Document → Query SPEC elements → Implement code → Test → Document → Commit.

--- a/docs/syspilot/userstories/us_installer.rst
+++ b/docs/syspilot/userstories/us_installer.rst
@@ -1,0 +1,49 @@
+Installer Agent
+===============
+
+
+.. story:: Installer Agent
+   :id: SYSP_US_INSTALLER
+   :status: draft
+   :priority: mandatory
+   :tags: agent-v2, installer
+   :links: SYSP_US_AGENT_ARCH, SYSP_US_SETUP
+
+   **As a** syspilot user,
+   **I want** an Installer agent that is invoked by the Setup Bootloader and
+   performs all installation and update work for non-manifest files,
+   **so that** I get a functioning, validated syspilot environment without
+   losing my local customizations during updates.
+
+   **Soul:**
+   The Installer SHALL be a thorough, methodical engineer — diligent and
+   reliable. It never leaves a broken state. It validates every installation
+   before reporting success. It is user-friendly in its reporting even though
+   it is not directly invoked by the user.
+
+   **Duties:**
+
+   - Keep all syspilot product components in the target project complete and
+     correct after every successful run
+   - Preserve local user customizations across updates
+   - Ensure the installation is functional (passes sphinx-build) before
+     reporting success — never leave a half-installed state
+   - Leave a traceable Git commit after every successful installation
+   - Reject installation of mutually exclusive Skills and report the conflict
+
+   **Workflow (high-level):**
+   Determine install source and mode → verify dependencies → install or
+   update all files (preserving user customizations) → configure Sphinx →
+   validate with sphinx-build → create baseline Git commit.
+
+   **Acceptance Criteria:**
+
+   1. Given a fresh project, When the Installer runs, Then all syspilot product
+      files are correctly placed and the project builds cleanly
+   2. Given an update, When the Installer runs, Then my ``tools:`` customizations
+      in agent files survive the update
+   3. Given any installation, When the Installer completes, Then a Git commit
+      documents exactly what was changed
+   4. Given a Skill that belongs to an exclusive group is being installed, When
+      a Skill from the same exclusive group is already installed, Then the
+      Installer SHALL reject the installation and report the conflict

--- a/docs/syspilot/userstories/us_jarvis.rst
+++ b/docs/syspilot/userstories/us_jarvis.rst
@@ -1,0 +1,49 @@
+Jarvis Inter-Agent Communication
+=================================
+
+
+.. story:: Jarvis Inter-Agent Communication
+   :id: SYSP_US_JARVIS
+   :status: draft
+   :priority: mandatory
+   :tags: agent-v2, infrastructure, jarvis, communication
+   :links: SYSP_US_AGENT_ARCH
+
+   **As a** syspilot user,
+   **I want** the syspilot manager agents to communicate with each other
+   reliably via a defined messaging mechanism,
+   **so that** completion notifications, findings reports, and merge
+   approval decisions reach the right agent without me needing to relay
+   messages manually between agents.
+
+   **Context:**
+
+   Several coordination events in the syspilot workflow require one manager
+   agent to send structured information to another without user mediation:
+
+   * CM → PM: change completion notification (Change Document path + summary)
+   * CM → QM: targeted check trigger (Change Document path for scope)
+   * QM → PM: Findings Report (per-level pass/fail with finding details)
+   * CM → PM: post-merge confirmation (commit hash + branch name)
+   * PM → CM: merge approval decision (approve / hold + rationale)
+
+   Jarvis is the named mechanism for this inter-agent communication. It is
+   a tool (``syspilot_jarvis_tools``) that exposes ``jarvis_sendToSession``
+   for sending structured messages between agent sessions. Agents that need
+   to send or receive these messages must declare ``syspilot_jarvis_tools``
+   in their ``tools:`` frontmatter field.
+
+   **Acceptance Criteria:**
+
+   1. Given CM completes a change, When it notifies PM and QM, Then both agents
+      receive the Change Document path and completion summary without user
+      intervention
+   2. Given QM produces a Findings Report, When routing to PM, Then the report
+      reaches PM without user relay
+   3. Given PM makes a merge approval decision, When communicating to CM, Then
+      CM receives the decision (approve / hold) with rationale
+   4. Given CM successfully merges to development, When sending post-merge
+      confirmation, Then PM receives merge commit hash and branch name
+   5. Given any agent that sends or receives Jarvis messages, When its
+      frontmatter is read, Then ``syspilot_jarvis_tools`` is listed in its
+      ``tools:`` field

--- a/docs/syspilot/userstories/us_project_mgr.rst
+++ b/docs/syspilot/userstories/us_project_mgr.rst
@@ -22,15 +22,22 @@ Project Manager Agent
    It never executes technical work directly.
 
    **Duties:**
-   Der Project Manager ist verantwortlich für:
 
-   * die vollständige CR-Übersetzung zwischen User-Bedarf und ausführbarem Change Request — kein artikulierter User-Bedarf bleibt ohne CR oder dokumentierte Reject-Begründung
-   * die Trennschärfe der CR-Sprache — CRs enthalten ausschließlich Intent (WHAT) und Motivation (WHY), keine technischen Vorgaben
-   * die Priorisierungs-Klarheit — zu jedem Zeitpunkt existiert eine begründete Reihenfolge der pending features
-   * die strukturelle Vorbereitung jeder Change-Pipeline — vor jedem CR-Versand existiert der Feature-Branch und das Change Document (Template-Kopie mit ausgefülltem Header und Summary)
-   * die Integration in ``development`` — PM führt den Merge von Feature-Branches nach ``development`` durch; kein anderer Agent merged
-   * die Verantwortung für QM-Findings-Decisions — fix-now / defer / accept-as-is wird von PM entschieden, nicht delegiert
-   * die Auslösung der Post-Release-Instance-Updates — nach jedem erfolgreichen Release stößt PM die Setup-Aktualisierung an
+   * Translate user needs into actionable Change Requests — no articulated need
+     remains without a CR or a documented reject rationale
+   * Maintain CR language purity — CRs contain exclusively intent (WHAT) and
+     motivation (WHY), never technical specifications or process steps
+   * Maintain prioritization clarity — a reasoned priority ordering of pending
+     features exists at all times
+   * Hold structural preparation for every change pipeline — before every CR
+     dispatch, the feature branch and Change Document (template copy with
+     completed header and summary) exist
+   * Hold merge authority — PM performs the merge of feature branches to
+     ``development``; no other agent merges
+   * Own QM findings decisions — fix-now / defer / accept-as-is is decided by
+     PM, never delegated
+   * Trigger post-release instance updates — after every successful release, PM
+     initiates the Setup Agent update
 
    **Workflow (high-level):**
    User intake → Assess → Research (if needed) → Plan → CR Content Check → Delegate to CM → Track.

--- a/docs/syspilot/userstories/us_quality_mece.rst
+++ b/docs/syspilot/userstories/us_quality_mece.rst
@@ -22,12 +22,15 @@ Quality Engineer MECE Agent
    Exhaustive (no gaps). It reports findings but never modifies specifications.
 
    **Duties:**
-   Die MECE-Engine ist verantwortlich für:
 
-   * die vollständige Abdeckung der Items des geprüften Levels — kein Item bleibt ungeprüft
-   * die Sichtbarkeit von Überlappungen — gefundene Überlappungen werden mit Details ausgewiesen, nicht implizit gelassen
-   * die Sichtbarkeit von Lücken — fehlende Coverage wird benannt, nicht stillschweigend übergangen
-   * die strikte Level-Begrenzung — ein Lauf prüft genau ein Level, vermischt L0/L1/L2 nicht
+   * Provide complete coverage of every item at the checked level — no item
+     remains unexamined
+   * Make overlaps visible — every detected overlap is reported with specific
+     details, never left implicit
+   * Make gaps visible — missing coverage is explicitly named, never silently
+     passed over
+   * Enforce strict level boundaries — one run checks exactly one level;
+     L0, L1, and L2 are never mixed
 
    **Workflow (high-level):**
    Receive level → Read all items → Analyze (overlaps, gaps, contradictions) → Report findings.

--- a/docs/syspilot/userstories/us_quality_mgr.rst
+++ b/docs/syspilot/userstories/us_quality_mgr.rst
@@ -22,14 +22,19 @@ Quality Manager Agent
    found, it produces a Findings Report addressed to PM.
 
    **Duties:**
-   Der Quality Manager ist verantwortlich für:
 
-   * die unabhängige Qualitätsbewertung der Spezifikations-Hierarchie — ohne in den aktiven Change-Flow eingreifen zu müssen
-   * die Per-Level-Trennschärfe der Befunde — L0, L1 und L2 Findings sind jeweils klar zugeordnet, nicht vermischt
-   * die Sichtbarkeit aller Befunde an PM — keine Quality-Issue verbleibt im QM ohne Adressat
-   * die klare Aussage über den Qualitätszustand — "clean bill of health" oder strukturierter Findings-Report, niemals etwas dazwischen
-   * die Zielgenauigkeit des CR-getriggerten Targeted-Checks — bei CM-Completion-Notification fokussiert QM ausschließlich auf die im Change deklarierten Elemente
-   * die vollständige Quality-Check-Abdeckung — MECE, Trace und Schema werden bei jedem Audit ausgeführt, kein Check-Typ wird ausgelassen
+   * Perform independent quality assessment of the specification hierarchy —
+     without participating in or influencing the active change flow
+   * Separate findings per level — L0, L1, and L2 findings are always clearly
+     assigned, never mixed
+   * Ensure all findings reach PM — no quality issue remains internal to QM
+     without an addressee
+   * Produce an unambiguous quality statement — either a clean bill of health or
+     a structured Findings Report, never an intermediate state
+   * Scope targeted checks precisely — when triggered by a CM completion
+     notification, focus exclusively on elements declared in the Change Document
+   * Guarantee complete check coverage — MECE, Trace, and Schema checks all run
+     in every audit; no check type is omitted
 
    **Workflow (high-level):**
    Trigger → Plan scope → Dispatch MECE (per level) + Trace → Collect findings →

--- a/docs/syspilot/userstories/us_release_engineer.rst
+++ b/docs/syspilot/userstories/us_release_engineer.rst
@@ -22,14 +22,19 @@ Release Engineer Agent
    never rewrites history. When in doubt, it stops and asks.
 
    **Duties:**
-   Der Release Engineer ist verantwortlich für:
 
-   * die versionierte Markierung im Git-Tree, die den freigegebenen Zustand eindeutig identifizierbar macht (Tag)
-   * die Validität des released Stands gegenüber den Qualitätsgates — nichts wird released, das die Sphinx-Validierung nicht besteht
-   * die vollständige Nachvollziehbarkeit dessen, was in dieser Version steckt — kein Change-Dokument fehlt in der Archivierung, Release Notes spiegeln vollständig wider was archiviert wurde
-   * die konsistente Versions-Identität über alle Quellen hinweg — Frontmatter, Tag, Release Notes referenzieren dieselbe Version
-   * die Trennschärfe zwischen Entwicklungslinie und freigegebener Linie — nach einem Release gibt es keinen Halbzustand zwischen ``development`` und ``main``
-   * die Bereinigung von Feature-Branches — nach jedem Release werden alle bereits in ``development`` gemergten Feature-Branches gelöscht; bis dahin bleiben sie für forensische Zwecke erhalten
+   * Create a versioned Git tag that uniquely identifies the released state
+   * Guarantee quality gate validity — nothing is released that does not pass
+     Sphinx validation
+   * Ensure complete release traceability — every change document is archived
+     and every archived document is reflected in the release notes
+   * Maintain consistent version identity across all sources — frontmatter,
+     tag, and release notes all reference the same version
+   * Enforce branch separation — after a release, there is no half-state
+     between ``development`` and ``main``
+   * Clean up feature branches — after every release, all feature branches
+     already merged into ``development`` are deleted; until then they are
+     retained for forensic purposes
 
    **Workflow (high-level):**
    Archive change docs → version bump → release notes → validate →

--- a/docs/syspilot/userstories/us_schema_check.rst
+++ b/docs/syspilot/userstories/us_schema_check.rst
@@ -1,0 +1,47 @@
+Quality Engineer Schema Check
+==============================
+
+
+.. story:: Schema Validation for Specification Files
+   :id: SYSP_US_SCHEMA
+   :status: draft
+   :priority: mandatory
+   :tags: agent-v2, quality, schema, validation
+   :links: SYSP_US_AGENT_ARCH, SYSP_US_QM
+
+   **As a** syspilot user,
+   **I want** the Quality Manager to validate that all specification files
+   conform to the sphinx-needs schema (required fields, valid status values,
+   correct ID prefixes, and consistent link separators),
+   **so that** structural defects in spec files are caught before they
+   silently corrupt traceability or cause sphinx-build failures.
+
+   **Context:**
+
+   The syspilot specification hierarchy uses sphinx-needs directives with
+   mandatory fields (``id``, ``status``, ``priority``, ``tags``, ``links``).
+   Structural violations — missing fields, non-standard status values, wrong
+   ID prefixes, mixed link separators — are not always caught by sphinx-build
+   and can silently break traceability queries, need filters, and impact
+   analysis.
+
+   A Schema Check complements MECE (horizontal consistency) and Trace
+   (vertical linkage) by verifying the structural correctness of each
+   individual need item against the defined field schema.
+
+   The QM's mandatory check trio is: MECE + Trace + Schema. All three
+   must run in every full audit.
+
+   **Acceptance Criteria:**
+
+   1. Given a full quality audit, When QM executes checks, Then a Schema check
+      runs alongside MECE and Trace — it is never omitted
+   2. Given a specification file, When the Schema check runs, Then every need
+      item is verified for: presence of ``id``, ``status``, ``priority``,
+      ``tags``, and ``links`` fields
+   3. Given a need with a non-standard ``status`` value, When detected, Then
+      the Schema check flags it as a finding
+   4. Given a need with an ID that does not match the expected prefix pattern
+      (SYSP_US_*, SYSP_REQ_*, SYSP_SPEC_*), When detected, Then it is flagged
+   5. Given a need with mixed link separators (semicolons vs. commas), When
+      detected, Then it is flagged with a recommendation to use commas

--- a/docs/syspilot/userstories/us_setup_engineer.rst
+++ b/docs/syspilot/userstories/us_setup_engineer.rst
@@ -23,12 +23,15 @@ Setup Manager Agent
    the Installer.
 
    **Duties:**
-   Der Setup Manager ist verantwortlich für:
 
-   - die Identität und Auffindbarkeit des einen, stabilen Einstiegspunkts in syspilot — der User muss nie wissen wie sich syspilot intern weiterentwickelt
-   - die Aktualität der ausgeführten Installations-Logik gegenüber dem Upstream-Stand — was lokal installiert ist, ist nicht maßgeblich
-   - die Versions-Kompatibilität zwischen sich selbst und dem Upstream — bei Inkompatibilität schützt er den User vor einem fehlerhaften Lauf
-   - die Manifest-Treue der platzierten Dateien — genau die Dateien aus bootstrap.json werden platziert, nicht mehr und nicht weniger
+   - Maintain the identity and discoverability of the single, stable syspilot
+     entry point — users never need to know how syspilot evolves internally
+   - Always execute current upstream installation logic — the locally installed
+     version is never authoritative
+   - Enforce version compatibility — protect the user from a faulty run when the
+     upstream manifest signals incompatibility
+   - Guarantee manifest fidelity — exactly the files declared in bootstrap.json
+     are placed, no more and no less
 
    **Workflow (high-level):**
    Fetch upstream manifest → validate manifest version → fetch and install each
@@ -42,46 +45,7 @@ Setup Manager Agent
    4. Given the Setup agent exists in my workspace, When I need to install or update syspilot, Then I can find and invoke exactly one entry point — without knowing any internal structure
 
 
-.. story:: Installer Agent
-   :id: SYSP_US_INSTALLER
-   :status: draft
-   :priority: mandatory
-   :tags: agent-v2, installer
-   :links: SYSP_US_AGENT_ARCH, SYSP_US_SETUP
+.. note::
 
-   **As a** syspilot user,
-   **I want** an Installer agent that is invoked by the Setup Bootloader and
-   performs all installation and update work for non-manifest files,
-   **so that** I get a functioning, validated syspilot environment without
-   losing my local customizations during updates.
-
-   **Soul:**
-   The Installer SHALL be a thorough, methodical engineer — diligent and
-   reliable. It never leaves a broken state. It validates every installation
-   before reporting success. It is user-friendly in its reporting even though
-   it is not directly invoked by the user.
-
-   **Duties:**
-   Der Installer ist verantwortlich für:
-
-   - die Vollständigkeit und Korrektheit der installierten syspilot-Komponenten im Zielprojekt
-   - die Erhaltung lokaler User-Anpassungen über Updates hinweg
-   - die Funktionsfähigkeit der Installation am Ende eines Laufs — nichts bleibt halb installiert oder unvalidiert
-   - die Nachvollziehbarkeit jeder Installation — jeder Lauf hinterlässt eine prüfbare Spur (Git-Commit)
-   - die Vermeidung von Konflikten zwischen sich gegenseitig ausschließenden Skills
-
-   **Workflow (high-level):**
-   Determine install source and mode → verify dependencies → install or
-   update all files (preserving user customizations) → configure Sphinx →
-   validate with sphinx-build → create baseline Git commit.
-
-   **Additional Acceptance Criteria:**
-
-   1. Given a fresh project, When the Installer runs, Then all syspilot product files are correctly placed and the project builds cleanly
-   2. Given an update, When the Installer runs, Then my ``tools:`` customizations in agent files survive the update
-   3. Given any installation, When the Installer completes, Then a Git commit documents exactly what was changed
-   4. Given a Skill that belongs to an exclusive group is being installed, When a Skill from the same exclusive group is already installed, Then the Installer SHALL reject the installation and report the conflict
-   5. Given any installation, When the Installer copies product files, Then only ``agents/``, ``prompts/``, ``skills/``, ``templates/`` from ``syspilot/`` are copied — syspilot-internal sources (``docs/syspilot/``, ``docs/changes/``) are never copied to user projects
-   6. Given a fresh project with no ``docs/index.rst``, When the Installer runs, Then a minimal starter ``index.rst`` is created; given a project that already has a ``docs/index.rst``, it is never overwritten
-   7. Given a file exists in ``.github/templates/`` but no longer exists in ``syspilot/templates/``, When the Installer runs, Then the orphan file is removed from ``.github/templates/``
-   8. Given any install or update, When the Installer completes the template sync, Then the run summary reports the count of templates installed, updated, and removed
+   The Installer Agent user story has been moved to its own file: :doc:`us_installer`.
+   See ``SYSP_US_INSTALLER`` in that file.

--- a/docs/syspilot/userstories/us_skill_branching.rst
+++ b/docs/syspilot/userstories/us_skill_branching.rst
@@ -11,7 +11,7 @@ Git branching rules for syspilot agents.
    :tags: agent-v2, skill, branching, workflow
    :links: SYSP_US_SKILL_ARCH
 
-   **As a** syspilot agent,
+   **As a** syspilot user,
    **I want** clear branching rules,
    **so that** I know where to commit and what branches to create.
 

--- a/docs/syspilot/userstories/us_skill_impact.rst
+++ b/docs/syspilot/userstories/us_skill_impact.rst
@@ -9,7 +9,7 @@ Impact analysis for specification elements.
    :status: draft
    :priority: mandatory
    :tags: agent-v2, skill, impact, traceability
-   :links: SYSP_US_DESIGN; SYSP_US_PM; SYSP_US_SKILL_ARCH
+   :links: SYSP_US_DESIGN, SYSP_US_PM, SYSP_US_SKILL_ARCH
 
    **As a** System Designer,
    **I want** a skill that provides impact analysis for Need elements,

--- a/docs/syspilot/userstories/us_skill_orchestration.rst
+++ b/docs/syspilot/userstories/us_skill_orchestration.rst
@@ -11,7 +11,7 @@ Manager-to-engineer orchestration pattern.
    :tags: agent-v2, skill, orchestration, architecture
    :links: SYSP_US_SKILL_ARCH
 
-   **As a** syspilot manager agent,
+   **As a** syspilot user,
    **I want** a defined orchestration pattern with generic verbs,
    **so that** engineer invocation is consistent, traceable, and
    independent of the underlying orchestration mechanism.

--- a/docs/syspilot/userstories/us_system_designer.rst
+++ b/docs/syspilot/userstories/us_system_designer.rst
@@ -22,13 +22,18 @@ System Designer Agent
    answer seems obvious.
 
    **Duties:**
-   Der System Designer ist verantwortlich für:
 
-   * die Vertikale Integrität der Spezifikations-Hierarchie — jede neue/geänderte Spec auf jedem Level ist mit Parent und Children konsistent verlinkt
-   * die MECE-Konformität auf jedem Level vor Übergang zum nächsten — keine Überlappungen, keine Lücken auf einer Ebene werden in die nächste vererbt
-   * die Status-Disziplin — neue Elemente starten als ``draft``, werden erst nach erfolgreicher Validierung auf ``approved`` gesetzt
-   * die Auditierbarkeit des Design-Verlaufs — das Change Document spiegelt zu jedem Zeitpunkt die getroffenen Entscheidungen und offenen Punkte
-   * die User-Approval-Disziplin in user-guided mode — kein Level wird ohne explizite Bestätigung verlassen
+   * Maintain vertical integrity of the specification hierarchy — every new or
+     changed spec at every level is consistently linked to its parent and
+     children
+   * Enforce MECE conformance before transitioning to the next level — no
+     overlaps or gaps are inherited downward
+   * Apply status discipline — new elements start as ``draft`` and are only set
+     to ``approved`` after successful validation
+   * Preserve design auditability — the Change Document reflects all decisions
+     made and open points at all times, including after interruption
+   * Apply user-approval discipline in user-guided mode — no level transition
+     occurs without explicit user confirmation
 
    **Workflow (high-level):**
    Intake → Level 0 (US) → Level 1 (REQ) → Level 2 (SPEC) →

--- a/docs/syspilot/userstories/us_test_engineer.rst
+++ b/docs/syspilot/userstories/us_test_engineer.rst
@@ -22,12 +22,15 @@ Test Engineer Agent
    meaningfully tested, it says so.
 
    **Duties:**
-   Der Test Engineer ist verantwortlich für:
 
-   * die Test-Coverage jedes Features — keine User Story bleibt ohne UAT-Chain
-   * die Manuelle Ausführbarkeit der UAT-Szenarien — jedes Test-Szenario kann von einem Menschen ohne weitere Annahmen durchgespielt werden
-   * die Sichtbarkeit von Untestbarkeit — wenn ein AC nicht meaningfully testbar ist, ist das im Output ausgewiesen, nicht verschwiegen
-   * die Traceability zwischen Feature, Test-Story, Test-Daten und Expected Outcomes — keine offene Test-Spur, kein Test ohne Anker
+   * Ensure test coverage of every feature — no user story remains without a
+     UAT chain
+   * Guarantee manual executability of UAT scenarios — every test scenario can
+     be executed by a human without additional assumptions
+   * Make untestability visible — when an AC cannot be meaningfully tested,
+     that fact is stated in the output, never silently omitted
+   * Maintain traceability between feature, test story, test data, and expected
+     outcomes — no open test chain, no test without an anchor
 
    **Workflow (high-level):**
    Read Change Document → identify feature USes → generate UAT chain per US →

--- a/docs/syspilot/userstories/us_verify_engineer.rst
+++ b/docs/syspilot/userstories/us_verify_engineer.rst
@@ -21,12 +21,16 @@ Verify Engineer Agent
    It never implements, only checks. Every claim must be backed by evidence.
 
    **Duties:**
-   Der Verify Engineer ist verantwortlich für:
 
-   * die Übereinstimmung zwischen spezifizierten Änderungen und tatsächlich umgesetzten Artefakten — keine Spec-Änderung ohne korrespondierende Implementation, keine Implementation ohne Spec-Anker
-   * die Lückenlosigkeit der Traceability für die im Change Document deklarierten Elemente — jede Linkkette ist End-to-End validiert
-   * die Sichtbarkeit von Diskrepanzen — gefundene Lücken werden im Validierungsbericht ausgewiesen, nicht eigenmächtig behoben
-   * die Existenz des Validierungsberichts als prüfbares Artefakt unter ``docs/changes/val-<name>.md`` — kein Verifikationslauf endet ohne Bericht
+   * Verify correspondence between specified changes and implemented artifacts —
+     no spec change without a corresponding implementation, no implementation
+     without a spec anchor
+   * Ensure traceability completeness for every element declared in the Change
+     Document — every link chain is validated end-to-end
+   * Make discrepancies visible — detected gaps are documented in the
+     validation report, never silently fixed
+   * Produce the validation report as a checkable artifact at
+     ``docs/changes/val-<name>.md`` — no verification run ends without a report
 
    **Workflow (high-level):**
    Receive Change Document → read specs → compare against implementation →


### PR DESCRIPTION
## Summary

QM audit remediation across all three specification levels. This PR fixes
structural gaps found during an independent quality audit of the specification
hierarchy. All fixes are targeted and non-destructive — no spec IDs are renamed
or removed, no behavior is changed.

---

## Problem Statement

The specification hierarchy had four classes of structural defects that silently
degraded spec quality and build reliability:

| Class | Scope | Impact |
|---|---|---|
| German Duties sections | 10 L0 user stories | Inconsistent language — spec body in German while all other content is in English |
| Non-human actors | 2 skill stories | Story format violation — user stories must describe human (or user-role) intent |
| Missing user story files | `SYSP_US_INSTALLER`, `SYSP_US_JARVIS`, `SYSP_US_SCHEMA` | sphinx-needs build error: existing reqs already link to `SYSP_US_INSTALLER` which did not exist |
| Semicolons in `:links:` | 13 req files, 5 spec files | sphinx-needs syntax error: the correct multi-value separator for `:links:` is comma, not semicolon |

Additionally, four targeted L2 spec gaps:

| ID | Gap |
|---|---|
| `SYSP_SPEC_CM_FRONTMATTER` | `syspilot.verify` missing from CM agents list — verify engineer is a CM-dispatched engineer |
| `SYSP_SPEC_VERIFY_FRONTMATTER` | Status stuck at `draft` — content is fully specified and implemented |
| `SYSP_SPEC_DESIGN_SOUL` / `SYSP_SPEC_DESIGN_DUTIES` | Tags `change` → `design` — System Designer is a `design` domain agent, not a `change` domain agent |
| `SYSP_SPEC_DOC_COPILOT_INSTRUCTIONS` | Status `open` → `draft` — `open` is not a valid status in `ubproject.toml` |

---

## Changes

### L0 — User Stories (13 files)

**German duties → English** (`us_change_mgr`, `us_project_mgr`, `us_quality_mgr`,
`us_system_designer`, `us_dev_engineer`, `us_test_engineer`, `us_quality_mece`,
`us_release_engineer`, `us_verify_engineer`, `us_setup_engineer`):
- German "verantwortlich für" block replaced with bullet-point English translation
- Content is semantically identical — only language changed

**Non-human actors:**
- `us_skill_orchestration`: `"syspilot manager agent"` → `"syspilot user"`
- `us_skill_branching`: `"syspilot agent"` → `"syspilot user"`

**New story files:**
- `us_installer.rst` — `SYSP_US_INSTALLER`: critical — 8 existing reqs in
  `req_setup_engineer.rst` already link to this ID; the missing file was a live
  sphinx-needs build error. The inline duplicate in `us_setup_engineer.rst` is
  removed and replaced with a cross-reference note.
- `us_jarvis.rst` — `SYSP_US_JARVIS`: documents the Jarvis inter-agent
  communication mechanism already referenced in PM/CM/QM agent frontmatters
- `us_schema_check.rst` — `SYSP_US_SCHEMA`: documents the QM schema validation
  check (third check in the MECE + Trace + Schema audit trio)

**Semicolons in `:links:`:**
- `us_skill_impact.rst`: 3 semicolons → commas

**Index update:** `us_installer`, `us_jarvis`, `us_schema_check` added to
`userstories/index.rst`

---

### L1 — Requirements (14 files)

**Semicolons → commas in `:links:`** (sphinx-needs requires comma as separator):

| File | Instances fixed |
|---|---|
| `req_project_mgr.rst` | 2 |
| `req_change_mgr.rst` | 2 |
| `req_quality_mgr.rst` | 2 |
| `req_setup_engineer.rst` | 2 |
| `req_dev_engineer.rst` | 1 |
| `req_verify_engineer.rst` | 1 |
| `req_release_engineer.rst` | 1 |
| `req_quality_mece.rst` | 1 |
| `req_quality_trace.rst` | 1 |
| `req_test_engineer.rst` | 1 |
| `req_docu_engineer.rst` | 1 |
| `req_system_designer.rst` | 1 |
| `req_skill_impact.rst` | 1 |

**New file:** `req_jarvis.rst` with three requirements:
- `SYSP_REQ_JARVIS_TOOL` — the `syspilot_jarvis_tools` messaging tool
- `SYSP_REQ_JARVIS_CONTRACT` — message payload structure contract
- `SYSP_REQ_JARVIS_FRONTMATTER` — per-agent frontmatter declaration requirement

**Index update:** `req_jarvis` added to `requirements/index.rst`

---

### L2 — Design Specs (5 files)

**Semicolons → commas in `:links:`** (5 files):
`spec_agent_arch`, `spec_skill_ask_questions`, `spec_skill_branching`,
`spec_skill_orchestration`, `spec_skill_impact`

**Targeted spec fixes:**

| ID | Change |
|---|---|
| `SYSP_SPEC_CM_FRONTMATTER` | Add `"syspilot.verify"` to agents list |
| `SYSP_SPEC_VERIFY_FRONTMATTER` | `status: draft` → `status: approved` |
| `SYSP_SPEC_DESIGN_SOUL` | `tags: …, change, soul` → `tags: …, design, soul` |
| `SYSP_SPEC_DESIGN_DUTIES` | `tags: …, change, duties` → `tags: …, design, duties` |
| `SYSP_SPEC_DOC_COPILOT_INSTRUCTIONS` | `status: open` → `status: draft` |

---

## Verification

- [ ] Zero remaining `:links:` semicolons across all `docs/syspilot/**/*.rst`
- [ ] Zero remaining German duty sections in L0 user stories
- [ ] `SYSP_US_INSTALLER` exists as a standalone file and is removed from the inline position in `us_setup_engineer.rst`
- [ ] `SYSP_US_JARVIS` and `SYSP_US_SCHEMA` exist and are indexed
- [ ] `SYSP_REQ_JARVIS_*` files exist and link upward to `SYSP_US_JARVIS`
- [ ] `syspilot.verify` present in CM agents list
- [ ] No spec has `status: open` (not a valid status value)
- [ ] Branch base is `development` — no fork-specific commits included

---

## Deferred (out of scope for this PR)

| Item | Rationale |
|---|---|
| `SYSP_REQ_INSTALLER_SOUL` / `SYSP_REQ_INSTALLER_FRONTMATTER` additions | Upstream has significantly rewritten the installer req set; adding these would require coordinating with the ongoing installer work |
| `req_jarvis.rst` L2 design specs | Requires separate System Designer pass to design the Jarvis spec layer |
| Status promotions beyond `SYSP_SPEC_VERIFY_FRONTMATTER` | Require explicit review against implementation state |
